### PR TITLE
AI-562: Make request timeout configurable and make default 90 seconds.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "solace_ai_connector>=0.1.3",
     "ratelimit~=2.2.1",
     "Flask-Cors~=5.0.0",
-    "solace-ai-connector-web",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "solace_ai_connector>=0.1.3",
     "ratelimit~=2.2.1",
     "Flask-Cors~=5.0.0",
-    "timeout-decorator~=0.5.0",
     "solace-ai-connector-web",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "solace_ai_connector>=0.1.3",
     "ratelimit~=2.2.1",
     "Flask-Cors~=5.0.0",
+    "timeout-decorator~=0.5.0",
     "solace-ai-connector-web",
 ]
 

--- a/src/solace_ai_connector_rest/components/rest_input.py
+++ b/src/solace_ai_connector_rest/components/rest_input.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generator
 from uuid import uuid4
 from werkzeug.utils import secure_filename
 from flask import request, Response
-import timeout_decorator
+from timeout_decorator import timeout, TimeoutError
 from ratelimit import limits, sleep_and_retry
 from solace_ai_connector.common.message import Message
 from solace_ai_connector.common.event import Event, EventType

--- a/src/solace_ai_connector_rest/components/rest_input.py
+++ b/src/solace_ai_connector_rest/components/rest_input.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generator
 from uuid import uuid4
 from werkzeug.utils import secure_filename
 from flask import request, Response
+import timeout_decorator
 from ratelimit import limits, sleep_and_retry
 from solace_ai_connector.common.message import Message
 from solace_ai_connector.common.event import Event, EventType
@@ -178,6 +179,7 @@ class RestInput(RestBase):
         @self.app.route(self.endpoint, methods=["POST"])
         @sleep_and_retry
         @limits(self.rate_limit, self._rate_limit_time_period)
+        @timeout(90)
         def request_handler():
             prompt = request.form.get("prompt")
             stream = request.form.get("stream")

--- a/src/solace_ai_connector_rest/components/rest_input.py
+++ b/src/solace_ai_connector_rest/components/rest_input.py
@@ -175,8 +175,6 @@ class RestInput(RestBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.listen_port = self.get_config("listen_port", 5050)
-        self._rate_limit_time_period = 60  # in seconds
 
     def _load_config(self):
         """Load configuration parameters."""
@@ -188,6 +186,10 @@ class RestInput(RestBase):
         self.authentication_enabled = self.authentication.get("enabled", False)
         if self.authentication_enabled:
             self.authentication_server = self.authentication.get("server")
+        
+        self.listen_port = self.get_config("listen_port", 5050)
+        self._rate_limit_time_period = 60  # in seconds
+
 
     def _create_request_handler(self):
         """Create and return the request handler function."""

--- a/src/solace_ai_connector_rest/components/rest_input.py
+++ b/src/solace_ai_connector_rest/components/rest_input.py
@@ -15,7 +15,7 @@ from solace_ai_connector.common.log import log
 from .rest_base import RestBase, info as base_info
 from .utils import create_api_response, get_user_info
 
-# Constants
+# Define constants
 REQUEST_TIMEOUT_MESSAGE = "Request timed out"
 
 # Clone and modify the info dictionary


### PR DESCRIPTION
## What is the purpose of this change?

To add a timeout mechanism for API requests to prevent the default 60 second timeout.

## How is this accomplished?

- Added a configurable timeout parameter with a default of 90 seconds
- Implemented timeout handling for both streaming and non-streaming responses
- Created a `RequestTimeoutError` class for proper error handling
- For streaming responses: added a background thread that monitors the timeout
- For simple responses: added time tracking to check elapsed time against the timeout threshold
- Added proper error responses when timeouts occur (408 status code)

## Anything reviews should focus on/be aware of?

- The threading approach used for streaming responses to avoid blocking the main thread
- Error handling has been improved to catch and report both timeout errors and other exceptions
- The default timeout value of 90 seconds - is this appropriate for most use cases?
- No changes to existing functionality - this is purely an enhancement for better request handling