### PR TITLE
Revert pytoml changes to remove web connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ dependencies = [
     "requests_oauthlib==2.0.0",
     "solace_ai_connector>=0.1.3",
     "ratelimit~=2.2.1",
-    "Flask-Cors~=5.0.0",
-    "solace-ai-connector-web",
+    "Flask-Cors~=5.0.0"
 ]
 
 [project.urls]
@@ -34,8 +33,6 @@ homepage = "https://github.com/SolaceLabs/solace-ai-connector-rest"
 repository = "https://github.com/SolaceLabs/solace-ai-connector-rest"
 documentation = "https://github.com/SolaceLabs/solace-ai-rest/blob/main/docs/components/index.md"
 
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/solace_ai_connector_rest"]


### PR DESCRIPTION
Updating the pytoml file to not have web connector as a dependency, this is included with Solace-Agent-Mesh hence not needed here. 